### PR TITLE
#17

### DIFF
--- a/auto.py
+++ b/auto.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     if puf.commit_message != "":
         try:
             print(puf.commit_message)
-            # puf.execute_command()
+            puf.execute_command()
         except Exception as e:
             print(e)
         else:

--- a/cptest_atcoder.py
+++ b/cptest_atcoder.py
@@ -1,49 +1,5 @@
-from ast import Raise
-import re
+from packages import *
 import sys
-import subprocess
-
-class AutoTest():
-
-    # ex) (contest_name, problem_name) = (abc210, a)
-    # ex) (contest_name, problem_name) = (typical90, ab)
-    def __init__(self, contest_name, problem_name, extension):
-        self.contest_name = contest_name
-        self.problem_name = problem_name
-        self.extension = extension
-
-        # source_code_path ex) abc/210/a.cpp, arc/10/a.cpp, typical90/ab.cpp
-        if res := re.search(r'^(a[a-z]c)(?=\d+)', self.contest_name):
-            res = res.group()
-            self.source_code_path = f'{res}/{self.contest_name[3:]}/{self.problem_name}.{self.extension}'
-        else:
-            self.source_code_path = f'{self.contest_name}/{self.problem_name}.{self.extension}'
-
-    # ex) https://abc210.contest.atcoder.jp/tasks/abc210_a
-    # ex) https://typical90.contest.atcoder.jp/tasks/typical90_a
-    def download_test_cases(self):
-        execute_command = f'oj dl "https://{self.contest_name}.contest.atcoder.jp/tasks/{self.contest_name}_{self.problem_name}"'
-        subprocess.run(execute_command, shell=True)
-
-    def execute_test_cases(self):
-
-        execute_command_list = []
-
-        if self.extension == 'cpp':
-            execute_command_list.append(f'g++ -Wfatal-errors -std=c++14 "{self.source_code_path}" -I .')
-            execute_command_list.append(f'cp {self.source_code_path} main.{self.extension}')
-            execute_command_list.append('oj test --ignore-spaces')
-            execute_command_list.append('rm -rf a.out test')
-        elif self.extension == 'py':
-            execute_command_list.append(f'cp {self.source_code_path} main.{self.extension}')
-            execute_command_list.append('oj test --ignore-spaces')
-            execute_command_list.append('oj test --ignore-spaces -c "python3 main.py"')
-            execute_command_list.append('rm -rf test')
-        else:
-            raise Exception
-
-        for execute_command in execute_command_list:
-            subprocess.run(execute_command, shell=True)
 
 # ex) abc210_a
 # ex) typical90_a
@@ -56,7 +12,7 @@ if __name__ == '__main__':
             extension = 'cpp'
         try:
             #print(sys.argv[1].split('_'))
-            autotest = AutoTest(*sys.argv[1].split('_'), extension)
+            autotest = Aat.AtcoderAutoTest(*sys.argv[1].split('_'), extension)
             autotest.download_test_cases()
             autotest.execute_test_cases()
 

--- a/makef.py
+++ b/makef.py
@@ -1,77 +1,15 @@
-import os, sys
-import shutil
+from packages import *
+import sys
 
-"""
-テンプレ(template.cpp)をベースにして、コンテスト毎のフォルダを作成
-実行時引数にdelを渡すと、フォルダの削除も可能
-"""
-
-# 入力として受け取ったコンテストのフォルダを作成
-# これはabc223_aといった形式に沿わないコンテスト用
-# 例）dp_a
-def make_ex_con_dir(con_cat):
-
-    # コンテスト種別のフォルダを作成
-    if not os.path.exists(con_cat):
-        os.makedirs(con_cat)
-
-    for l in 'abcdefghijklmnopqrstuvwxyz':
-        tgt_file = os.path.join(con_cat, l+'.cpp')
-        if not os.path.exists(tgt_file):
-            shutil.copy("template.cpp", tgt_file)
-            print(tgt_file)
-        else:
-            print("既に存在するファイルです")
-
-
-# 入力として受け取ったコンテスト番号のフォルダを作成
-def make_con_dir(con_cat, con_num):
-
-    tgt_dir = os.path.join(con_cat, con_num)
-    # コンテスト種別のフォルダを作成
-    if not os.path.exists(con_cat):
-        os.makedirs(con_cat)
-
-    # その回のフォルダを作成
-    if not os.path.exists(tgt_dir):
-        os.makedirs(tgt_dir)
-
-    for l in 'abcde':
-        tgt_file = os.path.join(tgt_dir, l+'.cpp')
-        if not os.path.exists(tgt_file):
-            shutil.copy("template.cpp", tgt_file)
-            print(tgt_file)
-        else:
-            print("既に存在するファイルです")
-
-
-# 誤って作ってしまったコンテスト番号のフォルダを削除
-def del_con_dir(con_cat, con_num):
-
-    tgt_dir = os.path.join(con_cat, con_num)
-
-    # 指定されたコンテスト番号のフォルダを削除
-    if os.path.exists(tgt_dir):
-        shutil.rmtree(tgt_dir)
-    else:
-        print("そのフォルダは存在しません")
-
-    # もしそのコンテスト種別のフォルダが空なら、コンテスト種別のフォルダを削除
-    if len(os.listdir(con_cat)) == 0:
-        shutil.rmtree(con_cat)
-
-
-# 入力の引数に'del'を指定したらフォルダを削除、指定しなければフォルダ作成
+# 入力の引数に'del'を指定したらフォルダを削除
+# 指定しなければフォルダ作成
 if __name__ == '__main__':
-    #make_ex_con_dir('dp')
 
-    # コンテスト種別、コンテスト番号
-    #con_cat, con_num = input("以下の用に入力（abc 222）：").split()
-    con_cat = 'abc'
-    con_num = input('コンテスト番号を入力：')
+    # コンテスト名(abc210, typical90, dp)
+    con_name = input('コンテスト名を入力(abc210など)：')
 
+    mcf = Mcf.MakeContestFolder(con_name)
     if len(sys.argv) >= 2 and sys.argv[1] == 'del':
-        del_con_dir(con_cat, con_num)
+        mcf.del_contest_dir()
     else:
-        make_con_dir(con_cat, con_num)
-
+        mcf.make_contest_dir()

--- a/packages/__init__.py
+++ b/packages/__init__.py
@@ -1,1 +1,3 @@
 from packages import push_updated_files as Puf
+from packages import make_contest_folder as Mcf
+from packages import atcoder_auto_test as Aat

--- a/packages/atcoder_auto_test.py
+++ b/packages/atcoder_auto_test.py
@@ -1,0 +1,45 @@
+from ast import Raise
+import re
+import subprocess
+
+class AtcoderAutoTest():
+
+    # ex) (contest_name, problem_name) = (abc210, a)
+    # ex) (contest_name, problem_name) = (typical90, ab)
+    def __init__(self, contest_name, problem_name, extension):
+        self.contest_name = contest_name
+        self.problem_name = problem_name
+        self.extension = extension
+
+        # source_code_path ex) abc/210/a.cpp, arc/10/a.cpp, typical90/ab.cpp
+        if res := re.search(r'^(a[a-z]c)(?=\d+)', self.contest_name):
+            res = res.group()
+            self.source_code_path = f'{res}/{self.contest_name[3:]}/{self.problem_name}.{self.extension}'
+        else:
+            self.source_code_path = f'{self.contest_name}/{self.problem_name}.{self.extension}'
+
+    # ex) https://abc210.contest.atcoder.jp/tasks/abc210_a
+    # ex) https://typical90.contest.atcoder.jp/tasks/typical90_a
+    def download_test_cases(self):
+        execute_command = f'oj dl "https://{self.contest_name}.contest.atcoder.jp/tasks/{self.contest_name}_{self.problem_name}"'
+        subprocess.run(execute_command, shell=True)
+
+    def execute_test_cases(self):
+
+        execute_command_list = []
+
+        if self.extension == 'cpp':
+            execute_command_list.append(f'g++ -Wfatal-errors -std=c++14 "{self.source_code_path}" -I .')
+            execute_command_list.append(f'cp {self.source_code_path} main.{self.extension}')
+            execute_command_list.append('oj test --ignore-spaces')
+            execute_command_list.append('rm -rf a.out test')
+        elif self.extension == 'py':
+            execute_command_list.append(f'cp {self.source_code_path} main.{self.extension}')
+            execute_command_list.append('oj test --ignore-spaces')
+            execute_command_list.append('oj test --ignore-spaces -c "python3 main.py"')
+            execute_command_list.append('rm -rf test')
+        else:
+            raise Exception
+
+        for execute_command in execute_command_list:
+            subprocess.run(execute_command, shell=True)

--- a/packages/make_contest_folder.py
+++ b/packages/make_contest_folder.py
@@ -1,0 +1,88 @@
+import re
+import os
+import shutil
+
+"""
+テンプレ(template.cpp)をベースにして、コンテスト毎のフォルダを作成
+実行時引数にdelを渡すと、フォルダの削除も可能
+"""
+
+class MakeContestFolder:
+
+    contest_name = ''
+    contest_category = ''
+    contest_num = ''
+
+    contest_category_dict = {'abc': 5, 'typical90': 90, 'dp': 26}
+
+    def __init__(self, contest_name):
+        self.contest_name = contest_name
+        self.make_contest_name_and_contest_num()
+
+    # Get problem_name_list
+    # Like ['a', 'b', 'c', 'd', 'e']
+    def get_problem_name_list(self):
+
+        problem_name_list = []
+        for i in range(self.contest_category_dict[self.contest_category]):
+            problem_name = chr(ord('a') + i%26)
+            if i >= 26:
+                problem_name = chr(ord('a') + int(i//26) - 1) + problem_name
+            problem_name_list.append(problem_name)
+
+        return problem_name_list
+
+    # contest_nameからcontest_category, contest_numを生成する
+    def make_contest_name_and_contest_num(self):
+
+        # もしcontest名をcotnest_categoryとcontest_numに分けることが可能ならば
+        if res := re.search(r'^(a[a-z]c)(?=\d+)', self.contest_name):
+            self.contest_category = res.group()
+            self.contest_num = self.contest_name[3:]
+        else:
+            self.contest_category = self.contest_name
+
+    # 指定したコンテスト名のフォルダを作成
+    def make_contest_dir(self):
+
+        tgt_dir = self.contest_category
+        if self.contest_num != '':
+            tgt_dir = os.path.join(tgt_dir, self.contest_num)
+
+        # もしそのコンテストが登録されていれば
+        if self.contest_category in self.contest_category_dict:
+            # コンテスト種別のフォルダを作成
+            if self.contest_category != '' and not os.path.exists(self.contest_category):
+                os.makedirs(self.contest_category)
+
+            # その回のフォルダを作成
+            if self.contest_num != '' and not os.path.exists(tgt_dir):
+                os.makedirs(tgt_dir)
+
+            for l in self.get_problem_name_list():
+                tgt_file = os.path.join(tgt_dir, l+'.cpp')
+                if not os.path.exists(tgt_file):
+                    shutil.copy('template.cpp', tgt_file)
+                    # print(tgt_file, self.contest_num, self.contest_category)
+                    print(tgt_file)
+                else:
+                    print('既に存在するファイルです')
+        else:
+            print('そのコンテストは存在しません')
+
+    # 指定したコンテスト名のフォルダを削除
+    def del_contest_dir(self):
+
+        tgt_dir = self.contest_category
+        if self.contest_num != '':
+            tgt_dir = os.path.join(tgt_dir, self.contest_num)
+
+        # 指定されたコンテスト番号のフォルダを削除
+        if os.path.exists(tgt_dir):
+            shutil.rmtree(tgt_dir)
+        else:
+            print('そのフォルダは存在しません')
+
+        # もしそのコンテスト種別のフォルダが空なら、コンテスト種別のフォルダを削除
+        if len(os.listdir(self.contest_category)) == 0:
+            shutil.rmtree(self.contest_category)


### PR DESCRIPTION
問題
- [ ] 現状使用しているあらゆるコードはabcコンテストしか想定していない
- [ ] そのため、それ以外のコンテストでは殆ど機能を使えない

対処
- [ ] フォルダ作成(makef.py)、テスト(cptest_atcoder.py)、Gitプッシュ(auto.py)の機能をモジュール化し、packageフォルダの中にまとめた
- [ ] arc, ahc, dp, typical90でも同様の操作でフォルダ作成、テスト、Gitプッシュなどができるように
- [ ] ただしその分コードの分量が増えてしまったため、今後のリファクタリングが必要